### PR TITLE
Add an Issue Queue to this fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ VICE menu = F12
 Retroarch menu = F1
 ```
 
+**Issues**
+
+Visit the [escalade/libreelec.tv issue queue](https://github.com/escalade/LibreELEC.tv/pulls) for issues pertaining to this specific fork. For everything else, see the [LibreELEC Forum](https://forum.libreelec.tv).
+
 Original README.md below.
 
 # LibreELEC


### PR DESCRIPTION
It would be great to have issue queue discussions about this specific fork. While I understand forum threads, they get rather difficult to follow, particularily when you can't close discussions. It would be great if you could open up the issue queue over at https://github.com/escalade/LibreELEC.tv/settings so that we could discuss issues, as well as track related pull requests.

Thanks! Well done on this, been loving having RetroArch as part of LibreELEC.
