### PR TITLE
emulationstation: add zip extension to nds

### DIFF
--- a/packages/escalade/emulation/emulationstation/files/es_systems-generic.cfg
+++ b/packages/escalade/emulation/emulationstation/files/es_systems-generic.cfg
@@ -115,7 +115,7 @@ All systems must be contained within the <systemList> tag.-->
 		<name>nds</name>
 		<fullname>Nintendo DS</fullname>
 		<path>/storage/roms/nds</path>
-		<extension>.nds .bin</extension>
+		<extension>.nds .bin .zip</extension>
 		<command>/usr/bin/retroarch.start -L /tmp/cores/desmume_libretro.so %ROM%</command>
 		<platform>nds</platform>
 	</system>


### PR DESCRIPTION
Add the .zip extension to Nintendo - Nintendo DS.
