### PR TITLE
estuary: add options to disable emulators/spotify/chrome shortcuts

### DIFF
--- a/packages/mediacenter/kodi/files/app-shortcuts.patch
+++ b/packages/mediacenter/kodi/files/app-shortcuts.patch
@@ -1,6 +1,6 @@
---- a/xml/Home.xml	2016-11-30 21:39:51.000000000 +0000
-+++ b/xml/Home.xml	2016-12-02 11:32:27.735254121 +0000
-@@ -898,6 +898,18 @@
+--- a/xml/Home.xml
++++ b/xml/Home.xml
+@@ -896,6 +896,20 @@
  							<property name="id">weather</property>
  							<visible>!Skin.HasSetting(HomeMenuNoWeatherButton)</visible>
  						</item>
@@ -9,13 +9,38 @@
 +							<onclick>XBMC.System.Exec(/usr/bin/google-chrome-stable)</onclick>
 +							<thumb>DefaultAddonWebSkin.png</thumb>
 +							<property name="id">chrome</property>
++							<visible>!Skin.HasSetting(HomeMenuNoChromeButton)</visible>
 +						</item>
 +						<item>
 +							<label>Spotify</label>
 +							<onclick>XBMC.System.Exec(/usr/bin/spotify)</onclick>
 +							<thumb>DefaultAddonMusic.png</thumb>
 +							<property name="id">spotify</property>
++							<visible>!Skin.HasSetting(HomeMenuNoSpotifyButton)</visible>
 +						</item>
  					</content>
  				</control>
  				<control type="grouplist" id="700">
+--- a/xml/SkinSettings.xml
++++ b/xml/SkinSettings.xml
+@@ -213,6 +213,18 @@
+ 					<selected>!Skin.HasSetting(HomeMenuNoWeatherButton)</selected>
+ 					<onclick>Skin.ToggleSetting(HomeMenuNoWeatherButton)</onclick>
+ 				</control>
++				<control type="radiobutton" id="61800">
++					<label>Chrome</label>
++					<include>DefaultSettingButton</include>
++					<selected>!Skin.HasSetting(HomeMenuNoChromeButton)</selected>
++					<onclick>Skin.ToggleSetting(HomeMenuNoChromeButton)</onclick>
++				</control>
++				<control type="radiobutton" id="61900">
++					<label>Spotify</label>
++					<include>DefaultSettingButton</include>
++					<selected>!Skin.HasSetting(HomeMenuNoSpotifyButton)</selected>
++					<onclick>Skin.ToggleSetting(HomeMenuNoSpotifyButton)</onclick>
++				</control>
+ 			</control>
+ 			<control type="image">
+ 				<description>Dialog Header image</description>
+
+

--- a/packages/mediacenter/kodi/files/emu-shortcuts.patch
+++ b/packages/mediacenter/kodi/files/emu-shortcuts.patch
@@ -1,15 +1,32 @@
---- a/xml/Home.xml	2016-12-02 11:32:58.361920593 +0000
-+++ b/xml/Home.xml	2016-12-02 11:33:47.611920282 +0000
-@@ -912,6 +912,12 @@
+--- a/xml/Home.xml
++++ b/xml/Home.xml
+@@ -910,6 +910,13 @@
  							<property name="id">spotify</property>
- 							<visible>!Skin.HasSetting(HomeMenuNoFavButton)</visible>
+ 							<visible>!Skin.HasSetting(HomeMenuNoSpotifyButton)</visible>
  						</item>
 +						<item>
 +							<label>Emulators</label>
 +							<onclick>XBMC.System.Exec(/usr/bin/emulator-frontend.sh)</onclick>
 +							<thumb>DefaultAddonGame.png</thumb>
 +							<property name="id">emulationstation</property>
++							<visible>!Skin.HasSetting(HomeMenuNoEmulatorsButton)</visible>
 +						</item>
  					</content>
  				</control>
  				<control type="grouplist" id="700">
+--- a/xml/SkinSettings.xml
++++ b/xml/SkinSettings.xml
+@@ -225,6 +225,12 @@
+ 					<selected>!Skin.HasSetting(HomeMenuNoSpotifyButton)</selected>
+ 					<onclick>Skin.ToggleSetting(HomeMenuNoSpotifyButton)</onclick>
+ 				</control>
++				<control type="radiobutton" id="62000">
++					<label>Emulators</label>
++					<include>DefaultSettingButton</include>
++					<selected>!Skin.HasSetting(HomeMenuNoEmulatorsButton)</selected>
++					<onclick>Skin.ToggleSetting(HomeMenuNoEmulatorsButton)</onclick>
++				</control>
+ 			</control>
+ 			<control type="image">
+ 				<description>Dialog Header image</description>
+


### PR DESCRIPTION
Add settings to show/hide the shortcuts without copying the skin.