### PR TITLE
escalade: set path to DOSbox 'roms' to same as x86_64

### DIFF
--- a/packages/escalade/emulators/emulationstation/config/arm/es_systems.cfg
+++ b/packages/escalade/emulators/emulationstation/config/arm/es_systems.cfg
@@ -100,7 +100,7 @@
         <system>
                 <name>pc</name>
                 <fullname>DOSBox</fullname>
-                <path>/storage/roms/dosbox</path>
+                <path>/storage/roms/dos</path>
                 <extension>.exe .com .bat .conf .cue .iso</extension>
                 <command>/usr/bin/retroarch.sh /tmp/cores/dosbox_svn_libretro.so %ROM%</command>
 	</system>


### PR DESCRIPTION
Path on disk and in the x86_64 config is /storage/roms/dos
Update to the arm config to match.